### PR TITLE
Limit concurrent connections

### DIFF
--- a/fotolog-download.coffee
+++ b/fotolog-download.coffee
@@ -2,6 +2,9 @@ request = require 'request'
 fs = require 'fs'
 path = require 'path'
 
+# Maximum number of parallel connections
+parallelAvail = 10
+
 try
 	fs.statSync('./archive')
 catch e
@@ -10,6 +13,22 @@ catch e
 
 imageURLs = require './index.json'
 
-for url in imageURLs
-	console.log 'Starting download of', url
-	request(url).pipe(fs.createWriteStream("./archive/" + encodeURIComponent(url.slice(url.lastIndexOf('/')+1))));
+downloadImage = (i) ->
+	url = imageURLs[i]
+	console.log 'Starting download of',url
+	request { url: url, encoding:'binary' }, (err, resp, data) ->
+		return console.error(err)  if err
+		fs.writeFile "./archive/" + encodeURIComponent(url.slice(url.lastIndexOf('/')+1)), data, 'binary', (e) ->
+			return console.error(e)  if e
+			parallelAvail++
+			parallelDownload()
+
+parallelDownload = () ->
+	if parallelAvail > 0 and imageIndex < imageURLs.length
+		parallelAvail--
+		downloadImage( imageIndex++ ) 
+		parallelDownload()
+
+
+imageIndex = 0
+parallelDownload()


### PR DESCRIPTION
I've written a function to manage the downloads in order to limit the number of concurrent connections to 10 (can be adjusted by variable parallelAvail).
